### PR TITLE
ci: add auto format git workflows

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -1,0 +1,22 @@
+name: Format
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          # Make sure the actual branch is checked out when running on pull requests
+          ref: ${{ github.head_ref }}
+          # This is important to fetch the changes to the previous commit
+          fetch-depth: 0
+      - name: Prettier format
+        uses: creyD/prettier_action@v4.2
+        with:
+          prettier_options: --write **/*.{ts,tsx,js,json}
+          only_changed: true
+          same_commit: true


### PR DESCRIPTION
Auto format code with `prettier` when a pull request is open. That makes sure everyone must follow the code format convention in case they disable it at local.